### PR TITLE
Move Who Wrote This Sh*t

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,6 @@ Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 - [Ruby Basic](https://github.com/xinuc/ruby_basic) - Learning material for Ruby Programming Language, written in Bahasa Indonesia.
 
 
-## Pentest
-
-- [Who Wrote This Sh*t](https://github.com/geovedi/who-wrote-this-shit) - Simple demonstration forensic linguistics program analysing a document.
-
-
 ## PHP
 
 - [PHP-BOOTSTRAP](https://github.com/Harazaki/PHP-BOOTSTRAP) - Simple design templates framework together with the famous bootstrap.
@@ -172,7 +167,7 @@ Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 - [Sastrawi](https://github.com/sastrawi/sastrawi) - High quality stemmer library for Indonesian Language.
 - [SentiStrengthID](https://github.com/masdevid/SentiStrengthID) - Sentiment Strength Detection in Bahasa Indonesia.
-
+- [Who Wrote This Sh*t](https://github.com/geovedi/who-wrote-this-shit) - Simple demonstration forensic linguistics program analysing a document.
 
 
 ## Miscellaneous


### PR DESCRIPTION
The Who Wrote This Sh*t repository is more appropriate if placed in Natural Language Processing category.