### PR TITLE
Remove autocomplete-python; Add WordGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,8 @@ Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ## Python
 
-- [Auto Complete Python](https://github.com/autocomplete-python/autocomplete-python) - Jedi based Python autocomplete for Atom.
+- [WordGraph](https://github.com/tistaharahap/WordGraph) - Weighting word frequency graph
+
 
 ## Natural Language Processing
 


### PR DESCRIPTION
autocomplete-python was added in 96e2d7d2d8; but it isn't Indonesian.
Fill empty section with WordGraph.