### PR TITLE
Sepamin Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 - [GoTral](https://github.com/codenoid/GoTral) - Go cenTralized config, for distributed software
 - [File.io Clone](https://github.com/codenoid/file.io) - File.io clone, file sharing with expiration
 - [Excel2Json](https://github.com/FerdinaKusumah/excel2json) - Convert your excel or excel datasource to json easily.
+- [Sepamin](https://github.com/FerdinaKusumah/sepamin) - Another spamming email that build from gmail.
 
 ## Haskell
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 - [Proctor](https://github.com/gojektech/proctor) - A Developer-Friendly Automation Orchestrator.
 - [GoTral](https://github.com/codenoid/GoTral) - Go cenTralized config, for distributed software
 - [File.io Clone](https://github.com/codenoid/file.io) - File.io clone, file sharing with expiration
+- [Excel2Json](https://github.com/FerdinaKusumah/excel2json) - Convert your excel or excel datasource to json easily.
 
 ## Haskell
 


### PR DESCRIPTION
Spamming repository that use gmail engine
reference [https://github.com/FerdinaKusumah/sepamin](https://github.com/FerdinaKusumah/sepamin)