### PR TITLE
Add NAEOS to Go category

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ This list aims to inspire others and hopefully give encouragement for individual
 - [Gubrak](https://github.com/novalagung/gubrak) - Golang functional utility library with syntactic sugar. It's like lodash, but for Go
 - [Godong](https://github.com/novalagung/godong) - Easiest dynamic http route handler for golang
 - [HiberSunda](https://github.com/hiberin/hibersunda) - The API to learn Undak Usuk Basa in Sundanese language.
+- [NAEOS](https://github.com/NAEOS-foundation/naeos) - Declarative platform engineering system: transforms specifications into validated multi-language project structures.
 
 ## Haskell
 


### PR DESCRIPTION
Add [NAEOS](https://github.com/NAEOS-foundation/naeos) - a declarative platform engineering system written in Go that transforms specifications into validated, multi-language project structures. Released v3.0.0 (86.9% test coverage, Docker images on GHCR).